### PR TITLE
envv.c: add missing headers

### DIFF
--- a/envv.c
+++ b/envv.c
@@ -38,7 +38,9 @@
 #include <pwd.h>
 #include <sys/types.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 /* Maximum number of components allowed in a colon-separated path list */
 


### PR DESCRIPTION
While compiling `envv` on recent versions of macOS, I received errors about undeclared functions `geteuid` and `strcasecmp`.

```
envv.c:181:18: error: call to undeclared function 'geteuid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   pw = getpwuid(geteuid());
[...]
envv.c:280:17: error: call to undeclared library function 'strcasecmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      if      (!strcasecmp(Directive, "set"))    what = D_SET;
```

- [`geteuid`](https://pubs.opengroup.org/onlinepubs/000095399/functions/geteuid.html) is declared in `unistd.h`
- [`strcasecmp`](https://pubs.opengroup.org/onlinepubs/009696799/functions/strcasecmp.html) is declared in `strings.h`

On some (most?) platforms, these headers might not need to be explicitly included for the functions to be declared (e.g. maybe the needed headers are already included by other headers), but including them would improve portability.